### PR TITLE
Add default recipe and attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,5 @@
+# default attributes, you should override these
+
+default[:mysql][:port] = '3306'
+default[:mysql][:version] = '5.7'
+default[:mysql][:password] = 'changeme'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,8 @@
+# Default installation target
+
+mysql_service 'std' do
+  port node[:mysql][:port]
+  version node[:mysql][:version]
+  initial_root_password node[:mysql][:password]
+  action [:create, :start]
+end


### PR DESCRIPTION
This adds a default recipe example to the cookbook, thus allowing it to install out of the box rather than requiring users to write a wrapper recipe to make use of it.
